### PR TITLE
Added more projects link, menu plugin

### DIFF
--- a/rpi_csdt_community/cms_plugins.py
+++ b/rpi_csdt_community/cms_plugins.py
@@ -1,0 +1,12 @@
+from cms.plugin_pool import plugin_pool
+from cms.plugin_base import CMSPluginBase
+from djangocms_text_ckeditor.cms_plugins import TextPlugin
+from djangocms_picture.cms_plugins import PicturePlugin
+from django.utils.translation import ugettext_lazy as _
+
+class MenuPlugin(CMSPluginBase):
+    name = _("Menu Plugin")
+    render_template = "rpi_csdt_community/menu_plugin.html"
+
+
+plugin_pool.register_plugin(MenuPlugin)

--- a/rpi_csdt_community/settings.py
+++ b/rpi_csdt_community/settings.py
@@ -256,6 +256,8 @@ CMS_TEMPLATES = (
     ('cms_bootstrap_templates/template_header_two_column_right.html', 'Two columns w/ header, large right'),
 )
 
+CMS_SOFTROOT = True
+
 REST_FRAMEWORK = {
     # Use hyperlinked styles by default.
     # Only used if the `serializer_class` attribute is not set on a view.

--- a/rpi_csdt_community/templates/rpi_csdt_community/menu_plugin.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/menu_plugin.html
@@ -1,0 +1,4 @@
+{% load menu_tags %}
+<ul>
+  {% show_menu 0 100 100 100 %}
+</ul>

--- a/templates/home.html
+++ b/templates/home.html
@@ -38,6 +38,10 @@
         {% endfor %}
     </div>
 
+    <div>
+      <h3><a href="{% url 'project-list' %}">More projects...</a></h3>
+    </div>
+
     <div class="span12">
         <h3>Catacloud <small>A cloud of categories</small></h3>
         <div class="container" style="margin-bottom: 20px;">


### PR DESCRIPTION
A request from Ron was to add "More projects..." to the bottom of the home page, and James wants a way to automatically add a navigation menu to the side for application contexts.

To add a menu, you add the "Menu Plugin" to the side, then select the root page->Advanced Settings->Soft Root = Yes