### PR TITLE
Unneeded library; included from libraries-vcs.txt

### DIFF
--- a/libraries.txt
+++ b/libraries.txt
@@ -29,4 +29,3 @@ djangocms-file==0.1
 djangocms-link==1.5
 djangocms-video==0.1
 django-analytical==0.21.0
-django-attachments==0.3.1.dev0


### PR DESCRIPTION
I'm merging this myself for 2 reasons;
 1. Time is of the essence
 2. It's a small change that won't affect production at all; hopefully it gets the Heroku app to be at least partially functional.