### PR TITLE
Changed the CMS menus to be Horizontal

### DIFF
--- a/rpi_csdt_community/templates/menu/menu.html
+++ b/rpi_csdt_community/templates/menu/menu.html
@@ -1,0 +1,14 @@
+
+
+{% load menu_tags %}
+
+	{% for child in children %}
+	<li class="child{% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}{% if child.sibling %} sibling{% endif %}{% if child.descendant %} descendant{% endif %}">
+		<a href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">{{ child.get_menu_title }}</a>
+		{% if child.children %}
+		<ul class="sub-menu">
+			{% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
+		</ul>
+		{% endif %}
+	</li>
+	{% endfor %}

--- a/rpi_csdt_community/templates/menu/menu.html
+++ b/rpi_csdt_community/templates/menu/menu.html
@@ -2,13 +2,13 @@
 
 {% load menu_tags %}
 
-	{% for child in children %}
-	<li class="child{% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}{% if child.sibling %} sibling{% endif %}{% if child.descendant %} descendant{% endif %}">
-		<a href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">{{ child.get_menu_title }}</a>
-		{% if child.children %}
-		<ul class="sub-menu">
-			{% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
-		</ul>
-		{% endif %}
-	</li>
-	{% endfor %}
+{% for child in children %}
+<li class="child{% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}{% if child.sibling %} sibling{% endif %}{% if child.descendant %} descendant{% endif %}">
+	<a href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">{{ child.get_menu_title }}</a>
+	{% if child.children %}
+	<ul class="sub-menu">
+		{% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
+	</ul>
+	{% endif %}
+</li>
+{% endfor %}

--- a/rpi_csdt_community/templates/rpi_csdt_community/menu_plugin.html
+++ b/rpi_csdt_community/templates/rpi_csdt_community/menu_plugin.html
@@ -1,4 +1,8 @@
+<div id="CMS_Menu">
 {% load menu_tags %}
+
 <ul>
-  {% show_menu 0 100 100 100 %}
+  {% show_menu 0 0 100 100 %}
+  {% show_menu 1 100 100 100 %}
 </ul>
+</div>

--- a/static/less/style.less
+++ b/static/less/style.less
@@ -148,3 +148,82 @@ a.liker {
 	max-width:200px;
 	float:left;
 }
+
+
+//stuff for the horizontal CMS menus
+#CMS_Menu
+{
+	margin-top:15px
+}
+
+#CMS_Menu ul
+{
+	list-style:none;
+	position:relative;
+	float:left;
+	margin:0;
+	padding:0
+}
+
+#CMS_Menu ul a
+{
+	display:block;
+	color:#333;
+	text-decoration:none;
+	font-weight:700;
+	font-size:12px;
+	line-height:32px;
+	padding:0 15px;
+	font-family:"HelveticaNeue","Helvetica Neue",Helvetica,Arial,sans-serif
+}
+
+#CMS_Menu ul li
+{
+	position:relative;
+	float:left;
+	margin:0;
+	padding:0
+}
+
+#CMS_Menu ul li.selected
+{
+	background:#ddd
+}
+
+#CMS_Menu ul li:hover
+{
+	background:#f6f6f6
+}
+
+#CMS_Menu ul ul
+{
+	display:none;
+	position:absolute;
+	top:100%;
+	left:0;
+	background:#fff;
+	padding:0
+}
+
+#CMS_Menu ul ul li
+{
+	float:none;
+	width:200px
+}
+
+#CMS_Menu ul ul a
+{
+	line-height:120%;
+	padding:10px 15px
+}
+
+#CMS_Menu ul ul ul
+{
+	top:0;
+	left:100%
+}
+
+#CMS_Menu ul li:hover > ul
+{
+	display:block
+}


### PR DESCRIPTION
I changed the menu plugin to give itself a division called CMS_Menu for
styling and create the root next to the first level

I then changed the base show menu command to label itself when it has a
sub menu

Finally I did some styling... I mostly stole from the internet...
because everyone uses the same method.